### PR TITLE
Update INSTALL.sh

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -17,7 +17,7 @@ prepare_host() {
 	local deps=()
 	local installed=$(dpkg-query -W -f '${db:Status-Abbrev}|${binary:Package}\n' '*' 2>/dev/null | grep '^ii' | awk -F '|' '{print $2}' | cut -d ':' -f 1)
 
-	if [[ "$DISTRIB" == "Ubuntu" ]] && [[ "$DISTRIB_RELEASE" == "18.10" || "$DISTRIB_RELEASE" =~ "20" ]]; then
+	if [[ "$DISTRIB" == "Ubuntu" ]] && [[ "$DISTRIB_RELEASE" == "18.10" || "$DISTRIB_RELEASE" =~ "20" || "$DISTRIB_RELEASE" =~ "21" ]]; then
 		hostdeps="$hostdeps lib32ncurses6"
 	else
 		hostdeps="$hostdeps lib32ncurses5"


### PR DESCRIPTION
Add ubuntu 21.x to the dependency check to install the proper lib32ncurses version.  No changes made elsewhere.